### PR TITLE
Allow strings or symbols as option keys

### DIFF
--- a/lib/akismet/client.rb
+++ b/lib/akismet/client.rb
@@ -286,14 +286,14 @@ module Akismet
 
       for key in env.keys
         if PARAM_TO_API_PARAM.value?(key.to_sym)
-          raise ArgumentError, "Environment variable '#{ key }' conflicts with built-in API parameter"
+          raise ArgumentError, "Environment variable #{ key.inspect } conflicts with built-in API parameter"
         end
       end
 
       params = params.each_with_object({}) do |(name, value), api_params|
         next if name == :env
 
-        api_name = PARAM_TO_API_PARAM[name] || raise(ArgumentError, "Invalid param: #{ name }")
+        api_name = PARAM_TO_API_PARAM[name.to_sym] || raise(ArgumentError, "Invalid param: #{ name.inspect }")
         api_params[api_name] = value
       end
 

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -160,4 +160,11 @@ class ClientTest < Minitest::Test
       @client.check 'ip', 'ua', invalid_param: 'invalid'
     end
   end
+
+  def test_params_can_be_symbols_or_keys
+    @client.check 'ip', 'ua', { author: 'Name' }
+    @client.check 'ip', 'ua', {'author' => 'Name'}
+    @client.check 'ip', 'ua', {env: { a: 1, b: 1 }}
+    @client.check 'ip', 'ua', {env: {'a' => 1, 'b' => 1}}
+  end
 end


### PR DESCRIPTION
Also use inspect if there is an error so that you can see whether the invalid key was a string or a
symbol.

It was confusing to pass {'author' => 'Name'} and get the error "Invalid param: author"